### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 
 # ✨ Overview
 
-> The v2023.0.0 release for the GEM's global vulnerability model is available! 🥳 🚀
+The v2023.0.0 release for the GEM's global vulnerability model is available! 🥳 🚀
 
 This repository hosts the most up-to-date versions of the vulnerability models
-for use in GEM's Global Risk Model. A detailed description of the complete workflow and vulnerability results is available at https://docs.openquake.org/vulnerability/
+for use in GEM's Global Risk Model. A detailed description of the complete workflow and vulnerability results is available [here](https://docs.openquake.org/vulnerability/)
 
 # 🌍 Region and country list
 
@@ -58,26 +58,27 @@ The following regions and countries/territories are covered in this repository.
 
 Inside each country's directory one can find a total of five files listed below
 
-- taxonomy_mapping_*.csv : This file has the complete list of building classes used in the exposure model and their match in the vulnerability model with the respesctive weight used by the OpenQuake-engine. If a specific mapping file exists for the country then that file should be used in calculations, if such file does not exist a regional mapping is provided in the directory.  
+- taxonomy_mapping_*.csv : This file has the complete list of building classes used in the exposure model and their match in the vulnerability model with the respesctive weight used by the [OpenQuake-engine](https://github.com/gem/oq-engine). If a specific mapping file exists for the country then that file should be used in calculations, if such file does not exist a regional mapping is provided in the directory.  
 - vulnerability_structural.xml : This file contains the vulnerability functions for structural elements used by OpenQuake-engine to compute economic losses.
 - vulnerability_nostructural.xml : This file contains the vulnerability functions for non-structural elements (drift and acceleration sensitive elements) used by OpenQuake-engine to compute economic losses.
 - vulnerability_contents.xml : This file contains the vulnerability functions for contents used by OpenQuake-engine to compute economic losses.
 - vulnerability_fatalities.xml : This file contains the vulnerability functions for occupants used by OpenQuake-engine to compute the number human casualties. 
 
+## How were the models developed?
+
+A complete description of the vulnerability modelling workflow is provided in the [documentation page](https://docs.openquake.org/vulnerability/). The models were developed using the Vulnerability Modellers Toolkit (VMTK) ([Martins et al 2021](https://doi.org/10.1007/s10518-020-00885-1)), a suite of tools developed by scientists working at the Global Earthquake Model Foundation and intended to provide earthquake engineers with a comprehensive platform to develop fragility and vulnerability models. The toolkit is freely accessible through its [github repository](https://github.com/GEMScienceTools/VMTK-Vulnerability-Modellers-ToolKit). A demonstration of the capabilities of the VMTK can be found [here](https://www.globalquakemodel.org/vmtk-webinar-2023)      
+
 ## Where can I find additional information on the defined building classes?
 
-The building classes defined within this exposure model follow the GEM Taxonomy convention. Please refer to the [GEM Taxonomy Glossary](https://taxonomy.openquake.org/) for additional details on taxonomy substrings.
-
+The building classes defined within this exposure model follow the [GEM Building Taxonomy v3.2 convention](https://github.com/gem/gem_taxonomy). Please refer to the [GEM Taxonomy Glossary](https://taxonomy.openquake.org/) for additional details on taxonomy substrings.
 
 # 📚 Publications
 
-Please cite the work as follows:
-(add zenodo DOI)
+Please cite the work as follows: (add zenodo DOI)
 
 # 🌟 Contributors 
 
 The authors are grateful for the input from dozens of local and international experts. A list of contributors can be found at https://www.globalquakemodel.org/risk-model-contributors.
-
 
 # License
 [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
@@ -100,9 +101,9 @@ By default you will see the files in the repository in the  `main` branch. Each 
 Note that the `main` branch could contain the work-in-progress of the next version of the model.
 
 ### How do I download the data for a given version?
-For each version, a related zip file is available in the [release section](https://github.com/gem/global_exposure_model/releases).
+For each version, a related zip file is available in the [release section](https://github.com/gem/global_vulnerability_model/releases).
 
-### Where can I find the models at the highest available resolution?
+### Where can I obtain the fragility functions or obtain vulnerability models for other risk metrics such as business interruption?
 
 Please contact us at product@globalquakemodel.org
 


### PR DESCRIPTION
Added the suggestions from @hcrowley to the initial readme.md.

1) corrected regions table to read 'Countries and territories'
2) linked OQ-engine GitHub repo
3) added version of GEM taxonomy
4) corrected section title to 'Where can I obtain the fragility functions or obtain vulnerability models for other risk metrics such as business interruption?'
5) added a new section referencing the VMTK (paper, repository and training material) 